### PR TITLE
QueryCouchDBWithPagination function is created

### DIFF
--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -19,6 +19,33 @@ func QueryCouchDB(ctx contractapi.TransactionContextInterface, query string) (qu
 	return
 }
 
+// QueryCouchDB lets you execute rich CouchDB queries with pagination
+func QueryCouchDBWithPagination(ctx contractapi.TransactionContextInterface, query string, pageSize int32, bookmark string) (queryResult *bytes.Buffer, err error) {
+	resultsIterator, queryResponseMetadata ,err := ctx.GetStub().GetQueryResultWithPagination(query, pageSize, bookmark)
+	if err != nil {
+		return
+	}
+	defer resultsIterator.Close()
+
+	records, err := constructQueryResponseFromIterator(resultsIterator)
+	if err != nil {
+		return
+	}
+
+	queryResult.WriteString(`{`)
+	queryResult.WriteString(`"records" :`)
+	queryResult.WriteString(records.String())
+	queryResult.WriteString(`,`)
+	queryResult.WriteString(`"bookmark" : "`)
+	queryResult.WriteString(queryResponseMetadata.GetBookmark())
+	queryResult.WriteString(`",`)
+	queryResult.WriteString(`"fetchedRecordsCount" : `)
+	queryResult.WriteString(string(queryResponseMetadata.GetFetchedRecordsCount()))
+	queryResult.WriteString(`}`)
+
+	return
+}
+
 // QueryPrivateData lets you execute rich private data queries
 func QueryPrivateData(ctx contractapi.TransactionContextInterface, collection string, query string) (queryResult *bytes.Buffer, err error) {
 	resultsIterator, err := ctx.GetStub().GetPrivateDataQueryResult(collection, query)


### PR DESCRIPTION
**Related issue**
You need the ability to perform paginated queries to the couchDB to get the information in small, easy-to-manage chunks.

**Describe the pull request**
The QueryCouchDBWithPagination function is created, which allows obtaining paginated queries using the GetQueryResultWithPagination function from the hyperledger / fabric-contract-api-go / contractapi package

**Tested**
Tested in local development environments
